### PR TITLE
Fix shortcut mode retaining physical album videos

### DIFF
--- a/lib/gpth_lib_exports.dart
+++ b/lib/gpth_lib_exports.dart
@@ -94,6 +94,7 @@ export 'steps/step_06_move_files/moving_strategies/moving_strategies.dart';
 export 'steps/step_06_move_files/services/file_operation_service.dart';
 export 'steps/step_06_move_files/services/moving_types.dart';
 export 'steps/step_06_move_files/services/path_generator_service.dart';
+export 'steps/step_06_move_files/services/shortcut_integrity_service.dart';
 export 'steps/step_06_move_files/services/step_06_move_media_entity_service.dart';
 export 'steps/step_06_move_files/services/symlink_service.dart';
 export 'steps/step_06_move_files/step_06_move_media_entities.dart';

--- a/lib/steps/step_06_move_files/moving_strategies/shortcut_moving_strategy.dart
+++ b/lib/steps/step_06_move_files/moving_strategies/shortcut_moving_strategy.dart
@@ -123,6 +123,7 @@ class ShortcutMovingStrategy extends MoveMediaEntityStrategy {
 
       // Collect synthetic shortcut secondaries after loops
       final List<FileEntity> pendingShortcutSecondaries = <FileEntity>[];
+      final MediaHashService mediaHashService = MediaHashService();
 
       // Per-entity, per-album registry of basenames already materialized as shortcuts
       // This avoids creating "(1)" when multiple originals share the same name.
@@ -143,15 +144,68 @@ class ShortcutMovingStrategy extends MoveMediaEntityStrategy {
           () => <String>{},
         );
 
-        // Helper to reuse existing shortcut if a basename already exists in this album
-        Future<File?> reuseIfExists(final String desiredName) async {
+        // Reuse actual links only. A regular file at this location must not be
+        // reported as a shortcut: that was the cause of video entries being
+        // silently retained as physical album files on a rerun.
+        Future<File?> reuseIfExistingShortcut(final String desiredName) async {
           final String candidate = path.join(albumDir.path, desiredName);
-          // Reuse if something already exists with this name (file/link/dir), or we already created it in this entity.
-          if (usedHere.contains(desiredName) ||
-              MovingStrategyUtils.existsAny(candidate)) {
+          if (usedHere.contains(desiredName) || await Link(candidate).exists()) {
             return File(candidate);
           }
           return null;
+        }
+
+        // A previous interrupted run can leave a regular file in the intended
+        // shortcut location. Shortcut mode must never leave physical media in
+        // Albums: identical duplicates are removed and distinct files are
+        // preserved outside Albums before the shortcut is created.
+        Future<void> clearRegularCandidateForShortcut(
+          final String desiredName,
+        ) async {
+          final String candidatePath = path.join(albumDir.path, desiredName);
+          if (await Link(candidatePath).exists()) return;
+
+          final File candidate = File(candidatePath);
+          if (!await candidate.exists()) return;
+
+          try {
+            final String candidateHash = await mediaHashService.calculateFileHash(
+              candidate,
+            );
+            final String canonicalHash = await mediaHashService.calculateFileHash(
+              movedPrimary,
+            );
+            if (candidateHash == canonicalHash) {
+              await candidate.delete();
+              logDebug(
+                '[Step 6/8] Removed stale physical album duplicate before '
+                "recreating shortcut: '$candidatePath'.",
+              );
+            } else {
+              final Directory conflictsDir = Directory(
+                path.join(
+                  context.outputDirectory.path,
+                  'Shortcut Conflicts',
+                  path.basename(albumDir.path),
+                ),
+              );
+              final File preserved = await _fileService.moveFile(
+                candidate,
+                conflictsDir,
+              );
+              logWarning(
+                '[Step 6/8] Moved conflicting physical album entry outside '
+                "Albums before recreating shortcut: '$candidatePath' -> '${preserved.path}'.",
+                forcePrint: true,
+              );
+            }
+          } catch (error) {
+            logWarning(
+              '[Step 6/8] Could not verify existing album entry before '
+              "creating shortcut '$candidatePath': $error",
+              forcePrint: true,
+            );
+          }
         }
 
         // Primary shortcut if originally non-canonical and belonged to this album
@@ -166,7 +220,8 @@ class ShortcutMovingStrategy extends MoveMediaEntityStrategy {
           final ssw = Stopwatch()..start();
           try {
             // 1) Try reuse if the same basename already exists in album
-            final File? existing = await reuseIfExists(desiredName);
+            await clearRegularCandidateForShortcut(desiredName);
+            final File? existing = await reuseIfExistingShortcut(desiredName);
             if (existing != null) {
               ssw.stop();
 
@@ -260,7 +315,8 @@ class ShortcutMovingStrategy extends MoveMediaEntityStrategy {
           final ssw = Stopwatch()..start();
           try {
             // First, reuse if an identical basename already exists here
-            final File? existing = await reuseIfExists(desiredName);
+            await clearRegularCandidateForShortcut(desiredName);
+            final File? existing = await reuseIfExistingShortcut(desiredName);
             if (existing != null) {
               ssw.stop();
 
@@ -363,7 +419,8 @@ class ShortcutMovingStrategy extends MoveMediaEntityStrategy {
           final String desiredName = path.basename(movedPrimary.path);
           final ssw = Stopwatch()..start();
           try {
-            final File? existing = await reuseIfExists(desiredName);
+            await clearRegularCandidateForShortcut(desiredName);
+            final File? existing = await reuseIfExistingShortcut(desiredName);
             final File shortcut =
                 existing ??
                 await MovingStrategyUtils.createSymlinkWithPreferredName(

--- a/lib/steps/step_06_move_files/moving_strategies/shortcut_moving_strategy.dart
+++ b/lib/steps/step_06_move_files/moving_strategies/shortcut_moving_strategy.dart
@@ -149,7 +149,8 @@ class ShortcutMovingStrategy extends MoveMediaEntityStrategy {
         // silently retained as physical album files on a rerun.
         Future<File?> reuseIfExistingShortcut(final String desiredName) async {
           final String candidate = path.join(albumDir.path, desiredName);
-          if (usedHere.contains(desiredName) || await Link(candidate).exists()) {
+          if (usedHere.contains(desiredName) ||
+              await Link(candidate).exists()) {
             return File(candidate);
           }
           return null;
@@ -169,12 +170,10 @@ class ShortcutMovingStrategy extends MoveMediaEntityStrategy {
           if (!await candidate.exists()) return;
 
           try {
-            final String candidateHash = await mediaHashService.calculateFileHash(
-              candidate,
-            );
-            final String canonicalHash = await mediaHashService.calculateFileHash(
-              movedPrimary,
-            );
+            final String candidateHash = await mediaHashService
+                .calculateFileHash(candidate);
+            final String canonicalHash = await mediaHashService
+                .calculateFileHash(movedPrimary);
             if (candidateHash == canonicalHash) {
               await candidate.delete();
               logDebug(

--- a/lib/steps/step_06_move_files/services/shortcut_integrity_service.dart
+++ b/lib/steps/step_06_move_files/services/shortcut_integrity_service.dart
@@ -12,9 +12,9 @@ import 'package:path/path.dart' as path;
 /// replacing an unexpected file by name alone could discard user data.
 class ShortcutIntegrityService with LoggerMixin {
   Future<ShortcutIntegritySummary> verifyAndRestore(
-    final MediaEntityCollection collection,
-    {required final Directory outputDirectory},
-  ) async {
+    final MediaEntityCollection collection, {
+    required final Directory outputDirectory,
+  }) async {
     var verified = 0;
     var restored = 0;
     var conflicts = 0;

--- a/lib/steps/step_06_move_files/services/shortcut_integrity_service.dart
+++ b/lib/steps/step_06_move_files/services/shortcut_integrity_service.dart
@@ -1,0 +1,133 @@
+import 'dart:io';
+
+import 'package:gpth_neo/gpth_lib_exports.dart';
+import 'package:path/path.dart' as path;
+
+/// Verifies album shortcuts after later pipeline stages have finished.
+///
+/// Shortcut mode deliberately stores only one physical file in ALL_PHOTOS. A
+/// later stage must therefore never silently turn an album entry back into a
+/// regular file. Missing links are restored from the entity's canonical output
+/// file. Existing regular files are reported, but deliberately not replaced:
+/// replacing an unexpected file by name alone could discard user data.
+class ShortcutIntegrityService with LoggerMixin {
+  Future<ShortcutIntegritySummary> verifyAndRestore(
+    final MediaEntityCollection collection,
+    {required final Directory outputDirectory},
+  ) async {
+    var verified = 0;
+    var restored = 0;
+    var conflicts = 0;
+
+    for (final entity in collection.asList()) {
+      final String? canonicalPath = entity.primaryFile.targetPath;
+      if (canonicalPath == null || canonicalPath.isEmpty) continue;
+
+      final File canonicalFile = File(canonicalPath);
+      if (!await canonicalFile.exists()) continue;
+
+      for (final shortcut in entity.secondaryFiles.where(
+        (final file) => file.isShortcut && file.targetPath != null,
+      )) {
+        final String shortcutPath = shortcut.targetPath!;
+        final Link link = Link(shortcutPath);
+        if (await link.exists()) {
+          verified++;
+          continue;
+        }
+
+        final FileSystemEntityType entryType = await FileSystemEntity.type(
+          shortcutPath,
+          followLinks: false,
+        );
+        if (entryType == FileSystemEntityType.link) {
+          // A broken link occupies the pathname and must be removed before it
+          // can be recreated against the canonical file.
+          try {
+            await link.delete();
+          } catch (error) {
+            conflicts++;
+            logError(
+              "[Step 7/8] Could not remove broken album shortcut '$shortcutPath': $error",
+              forcePrint: true,
+            );
+            continue;
+          }
+        }
+
+        final File regularFile = File(shortcutPath);
+        if (await regularFile.exists()) {
+          try {
+            final Directory conflictsDir = Directory(
+              path.join(
+                outputDirectory.path,
+                'Shortcut Conflicts',
+                'Post EXIF validation',
+              ),
+            );
+            final File preserved = await FileOperationService().moveFile(
+              regularFile,
+              conflictsDir,
+            );
+            logWarning(
+              '[Step 7/8] Moved unexpected physical album entry outside '
+              "Albums before restoring shortcut: '$shortcutPath' -> '${preserved.path}'.",
+              forcePrint: true,
+            );
+          } catch (error) {
+            conflicts++;
+            logError(
+              '[Step 7/8] Could not move unexpected physical album entry '
+              "'$shortcutPath' before restoring shortcut: $error",
+              forcePrint: true,
+            );
+            continue;
+          }
+        }
+
+        try {
+          final Directory parent = Directory(path.dirname(shortcutPath));
+          await parent.create(recursive: true);
+          final String relativeTarget = path.relative(
+            canonicalPath,
+            from: parent.path,
+          );
+          await link.create(relativeTarget);
+          restored++;
+        } catch (error) {
+          conflicts++;
+          logError(
+            '[Step 7/8] Could not restore album shortcut '
+            "'$shortcutPath' -> '$canonicalPath': $error",
+            forcePrint: true,
+          );
+        }
+      }
+    }
+
+    if (restored > 0 || conflicts > 0) {
+      logPrint(
+        '[Step 7/8] Album shortcut integrity: $verified verified, '
+        '$restored restored, $conflicts unresolved conflict(s).',
+      );
+    }
+
+    return ShortcutIntegritySummary(
+      verified: verified,
+      restored: restored,
+      conflicts: conflicts,
+    );
+  }
+}
+
+class ShortcutIntegritySummary {
+  const ShortcutIntegritySummary({
+    required this.verified,
+    required this.restored,
+    required this.conflicts,
+  });
+
+  final int verified;
+  final int restored;
+  final int conflicts;
+}

--- a/lib/steps/step_07_write_exif/services/step_07_write_exif_service.dart
+++ b/lib/steps/step_07_write_exif/services/step_07_write_exif_service.dart
@@ -1049,6 +1049,15 @@ class WriteExifProcessingService with LoggerMixin {
       pendingVideosByTagset.clear();
     }
 
+    // EXIF writes must only touch canonical output files. Verify that album
+    // entries created by shortcut mode still are links after the write phase.
+    // This catches and repairs a missing link. An unexpected regular album
+    // file is preserved under Shortcut Conflicts before its link is restored.
+    await ShortcutIntegrityService().verifyAndRestore(
+      collection,
+      outputDirectory: context.outputDirectory,
+    );
+
     // Unique-file metrics (same meaning/order)
     final gpsTotal = WriteExifAuxiliaryService.uniqueGpsFilesCount;
     final gpsPrim = WriteExifAuxiliaryService.uniqueGpsPrimaryCount;

--- a/test/integration/media_entity_moving_strategies_test.dart
+++ b/test/integration/media_entity_moving_strategies_test.dart
@@ -171,125 +171,132 @@ void main() {
         expect(albumDir.existsSync(), isTrue);
       });
 
-      test(
-        'creates album links for HEIC, MP4, and MOV files',
-        () async {
-          final files = <String>['live.HEIC', 'live.MP4', 'movie.MOV'];
+      test('creates album links for HEIC, MP4, and MOV files', () async {
+        final files = <String>['live.HEIC', 'live.MP4', 'movie.MOV'];
 
-          for (final name in files) {
-            final source = fixture.createFile('Album/$name', [1, 2, 3]);
-            final entity = MediaEntity.single(
-              file: FileEntity(sourcePath: source.path),
-              dateTaken: DateTime(2023, 6, 15),
-              albumsMap: {
-                'Album': AlbumEntity(
-                  name: 'Album',
-                  sourceDirectories: {source.parent.path},
-                ),
-              },
-            );
+        for (final name in files) {
+          final source = fixture.createFile('Album/$name', [1, 2, 3]);
+          final entity = MediaEntity.single(
+            file: FileEntity(sourcePath: source.path),
+            dateTaken: DateTime(2023, 6, 15),
+            albumsMap: {
+              'Album': AlbumEntity(
+                name: 'Album',
+                sourceDirectories: {source.parent.path},
+              ),
+            },
+          );
 
-            final results = <MoveMediaEntityResult>[];
-            await for (final result in strategy.processMediaEntity(
-              entity,
-              context,
-            )) {
-              results.add(result);
-            }
-
-            final linkResult = results.singleWhere(
-              (final result) =>
-                  result.operation.operationType ==
-                  MediaEntityOperationType.createSymlink,
-            );
-            final shortcut = Link(linkResult.resultFile!.path);
-            expect(
-              await shortcut.exists(),
-              isTrue,
-              reason: '$name must remain an album symlink in shortcut mode',
-            );
+          final results = <MoveMediaEntityResult>[];
+          await for (final result in strategy.processMediaEntity(
+            entity,
+            context,
+          )) {
+            results.add(result);
           }
+
+          final linkResult = results.singleWhere(
+            (final result) =>
+                result.operation.operationType ==
+                MediaEntityOperationType.createSymlink,
+          );
+          final shortcut = Link(linkResult.resultFile!.path);
+          expect(
+            await shortcut.exists(),
+            isTrue,
+            reason: '$name must remain an album symlink in shortcut mode',
+          );
+        }
+      });
+
+      test(
+        'restores a missing shortcut after later processing stages',
+        () async {
+          final source = fixture.createFile('Album/live.MP4', [1, 2, 3]);
+          final entity = MediaEntity.single(
+            file: FileEntity(sourcePath: source.path),
+            dateTaken: DateTime(2023, 6, 15),
+            albumsMap: {
+              'Album': AlbumEntity(
+                name: 'Album',
+                sourceDirectories: {source.parent.path},
+              ),
+            },
+          );
+
+          await for (final _ in strategy.processMediaEntity(entity, context)) {}
+
+          final shortcut = entity.secondaryFiles.singleWhere(
+            (final file) => file.isShortcut,
+          );
+          await Link(shortcut.targetPath!).delete();
+
+          final summary = await ShortcutIntegrityService().verifyAndRestore(
+            MediaEntityCollection([entity]),
+            outputDirectory: outputDir,
+          );
+
+          expect(summary.restored, equals(1));
+          expect(await Link(shortcut.targetPath!).exists(), isTrue);
         },
       );
 
-      test('restores a missing shortcut after later processing stages', () async {
-        final source = fixture.createFile('Album/live.MP4', [1, 2, 3]);
-        final entity = MediaEntity.single(
-          file: FileEntity(sourcePath: source.path),
-          dateTaken: DateTime(2023, 6, 15),
-          albumsMap: {
-            'Album': AlbumEntity(
-              name: 'Album',
-              sourceDirectories: {source.parent.path},
-            ),
-          },
-        );
+      test(
+        'replaces an identical stale physical video with a shortcut',
+        () async {
+          final source = fixture.createFile('Album/live.MP4', [1, 2, 3]);
+          final staleOutput = fixture.createFile(
+            'output/Albums/Album/live.MP4',
+            [1, 2, 3],
+          );
+          final entity = MediaEntity.single(
+            file: FileEntity(sourcePath: source.path),
+            dateTaken: DateTime(2023, 6, 15),
+            albumsMap: {
+              'Album': AlbumEntity(
+                name: 'Album',
+                sourceDirectories: {source.parent.path},
+              ),
+            },
+          );
 
-        await for (final _ in strategy.processMediaEntity(entity, context)) {}
+          await for (final _ in strategy.processMediaEntity(entity, context)) {}
 
-        final shortcut = entity.secondaryFiles.singleWhere(
-          (final file) => file.isShortcut,
-        );
-        await Link(shortcut.targetPath!).delete();
+          expect(await File(staleOutput.path).exists(), isTrue);
+          expect(await Link(staleOutput.path).exists(), isTrue);
+        },
+      );
 
-        final summary = await ShortcutIntegrityService().verifyAndRestore(
-          MediaEntityCollection([entity]),
-          outputDirectory: outputDir,
-        );
+      test(
+        'moves a distinct physical album entry outside Albums before linking',
+        () async {
+          final source = fixture.createFile('Album/live.MP4', [1, 2, 3]);
+          final staleOutput = fixture.createFile(
+            'output/Albums/Album/live.MP4',
+            [4, 5, 6],
+          );
+          final entity = MediaEntity.single(
+            file: FileEntity(sourcePath: source.path),
+            dateTaken: DateTime(2023, 6, 15),
+            albumsMap: {
+              'Album': AlbumEntity(
+                name: 'Album',
+                sourceDirectories: {source.parent.path},
+              ),
+            },
+          );
 
-        expect(summary.restored, equals(1));
-        expect(await Link(shortcut.targetPath!).exists(), isTrue);
-      });
+          await for (final _ in strategy.processMediaEntity(entity, context)) {}
 
-      test('replaces an identical stale physical video with a shortcut', () async {
-        final source = fixture.createFile('Album/live.MP4', [1, 2, 3]);
-        final staleOutput = fixture.createFile(
-          'output/Albums/Album/live.MP4',
-          [1, 2, 3],
-        );
-        final entity = MediaEntity.single(
-          file: FileEntity(sourcePath: source.path),
-          dateTaken: DateTime(2023, 6, 15),
-          albumsMap: {
-            'Album': AlbumEntity(
-              name: 'Album',
-              sourceDirectories: {source.parent.path},
-            ),
-          },
-        );
-
-        await for (final _ in strategy.processMediaEntity(entity, context)) {}
-
-        expect(await File(staleOutput.path).exists(), isTrue);
-        expect(await Link(staleOutput.path).exists(), isTrue);
-      });
-
-      test('moves a distinct physical album entry outside Albums before linking',
-          () async {
-        final source = fixture.createFile('Album/live.MP4', [1, 2, 3]);
-        final staleOutput = fixture.createFile(
-          'output/Albums/Album/live.MP4',
-          [4, 5, 6],
-        );
-        final entity = MediaEntity.single(
-          file: FileEntity(sourcePath: source.path),
-          dateTaken: DateTime(2023, 6, 15),
-          albumsMap: {
-            'Album': AlbumEntity(
-              name: 'Album',
-              sourceDirectories: {source.parent.path},
-            ),
-          },
-        );
-
-        await for (final _ in strategy.processMediaEntity(entity, context)) {}
-
-        expect(await Link(staleOutput.path).exists(), isTrue);
-        expect(
-          Directory('${outputDir.path}/Shortcut Conflicts/Album').existsSync(),
-          isTrue,
-        );
-      });
+          expect(await Link(staleOutput.path).exists(), isTrue);
+          expect(
+            Directory(
+              '${outputDir.path}/Shortcut Conflicts/Album',
+            ).existsSync(),
+            isTrue,
+          );
+        },
+      );
 
       test(
         'uses hard links in shortcut mode when hardlink is enabled on Windows',

--- a/test/integration/media_entity_moving_strategies_test.dart
+++ b/test/integration/media_entity_moving_strategies_test.dart
@@ -172,6 +172,126 @@ void main() {
       });
 
       test(
+        'creates album links for HEIC, MP4, and MOV files',
+        () async {
+          final files = <String>['live.HEIC', 'live.MP4', 'movie.MOV'];
+
+          for (final name in files) {
+            final source = fixture.createFile('Album/$name', [1, 2, 3]);
+            final entity = MediaEntity.single(
+              file: FileEntity(sourcePath: source.path),
+              dateTaken: DateTime(2023, 6, 15),
+              albumsMap: {
+                'Album': AlbumEntity(
+                  name: 'Album',
+                  sourceDirectories: {source.parent.path},
+                ),
+              },
+            );
+
+            final results = <MoveMediaEntityResult>[];
+            await for (final result in strategy.processMediaEntity(
+              entity,
+              context,
+            )) {
+              results.add(result);
+            }
+
+            final linkResult = results.singleWhere(
+              (final result) =>
+                  result.operation.operationType ==
+                  MediaEntityOperationType.createSymlink,
+            );
+            final shortcut = Link(linkResult.resultFile!.path);
+            expect(
+              await shortcut.exists(),
+              isTrue,
+              reason: '$name must remain an album symlink in shortcut mode',
+            );
+          }
+        },
+      );
+
+      test('restores a missing shortcut after later processing stages', () async {
+        final source = fixture.createFile('Album/live.MP4', [1, 2, 3]);
+        final entity = MediaEntity.single(
+          file: FileEntity(sourcePath: source.path),
+          dateTaken: DateTime(2023, 6, 15),
+          albumsMap: {
+            'Album': AlbumEntity(
+              name: 'Album',
+              sourceDirectories: {source.parent.path},
+            ),
+          },
+        );
+
+        await for (final _ in strategy.processMediaEntity(entity, context)) {}
+
+        final shortcut = entity.secondaryFiles.singleWhere(
+          (final file) => file.isShortcut,
+        );
+        await Link(shortcut.targetPath!).delete();
+
+        final summary = await ShortcutIntegrityService().verifyAndRestore(
+          MediaEntityCollection([entity]),
+          outputDirectory: outputDir,
+        );
+
+        expect(summary.restored, equals(1));
+        expect(await Link(shortcut.targetPath!).exists(), isTrue);
+      });
+
+      test('replaces an identical stale physical video with a shortcut', () async {
+        final source = fixture.createFile('Album/live.MP4', [1, 2, 3]);
+        final staleOutput = fixture.createFile(
+          'output/Albums/Album/live.MP4',
+          [1, 2, 3],
+        );
+        final entity = MediaEntity.single(
+          file: FileEntity(sourcePath: source.path),
+          dateTaken: DateTime(2023, 6, 15),
+          albumsMap: {
+            'Album': AlbumEntity(
+              name: 'Album',
+              sourceDirectories: {source.parent.path},
+            ),
+          },
+        );
+
+        await for (final _ in strategy.processMediaEntity(entity, context)) {}
+
+        expect(await File(staleOutput.path).exists(), isTrue);
+        expect(await Link(staleOutput.path).exists(), isTrue);
+      });
+
+      test('moves a distinct physical album entry outside Albums before linking',
+          () async {
+        final source = fixture.createFile('Album/live.MP4', [1, 2, 3]);
+        final staleOutput = fixture.createFile(
+          'output/Albums/Album/live.MP4',
+          [4, 5, 6],
+        );
+        final entity = MediaEntity.single(
+          file: FileEntity(sourcePath: source.path),
+          dateTaken: DateTime(2023, 6, 15),
+          albumsMap: {
+            'Album': AlbumEntity(
+              name: 'Album',
+              sourceDirectories: {source.parent.path},
+            ),
+          },
+        );
+
+        await for (final _ in strategy.processMediaEntity(entity, context)) {}
+
+        expect(await Link(staleOutput.path).exists(), isTrue);
+        expect(
+          Directory('${outputDir.path}/Shortcut Conflicts/Album').existsSync(),
+          isTrue,
+        );
+      });
+
+      test(
         'uses hard links in shortcut mode when hardlink is enabled on Windows',
         () async {
           if (!Platform.isWindows) return;


### PR DESCRIPTION
Fixes #143.

## Summary
- shortcut mode now reuses only real links, never regular files
- a stale physical album file is removed when it has the same full content hash as the canonical ALL_PHOTOS file
- a different physical album file is preserved under Shortcut Conflicts and replaced by the expected link, so Albums contains only shortcuts in shortcut mode
- post-EXIF integrity repair applies the same rule for missing, broken, or unexpectedly physical album entries
- add coverage for HEIC, MP4 and MOV shortcut output, missing-link restoration, and physical-video recovery

## Validation
- git diff --check
- Dart SDK is unavailable in the execution environment, so the GPTH Dart test suite could not be run locally.